### PR TITLE
Future Parser Changes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -115,13 +115,11 @@ class rancid (
   validate_re($locktime, '^(\d)+$', "rancid::locktime is ${locktime} and must match the regex of a number.")
   validate_re($parcount, '^(\d)+$', "rancid::parcount is ${parcount} and must match the regex of a number.")
 
-  $groups_type = type($groups)
-  if $groups_type != 'array' {
+  if ! is_array($groups_type) {
     fail("rancid::groups must be an array. Detected type is ${groups_type}.")
   }
 
-  $packages_type = type($packages)
-  if $packages_type != 'array' and $packages_type != 'string' {
+  if (! is_array($packages_type)) or (! is_string($packages_type)) {
     fail("rancid::packages must be an array or a string. Detected type is ${packages_type}.")
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,8 +119,8 @@ class rancid (
     fail("rancid::groups must be an array.")
   }
 
-  if (! is_array($packages)) or (! is_string($packages)) {
-    fail("rancid::packages must be an array or a string.")
+  if ! is_array($packages) {
+    fail("rancid::packages must be an array")
   }
 
   validate_absolute_path($rancid_config_real)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -115,12 +115,12 @@ class rancid (
   validate_re($locktime, '^(\d)+$', "rancid::locktime is ${locktime} and must match the regex of a number.")
   validate_re($parcount, '^(\d)+$', "rancid::parcount is ${parcount} and must match the regex of a number.")
 
-  if ! is_array($groups_type) {
-    fail("rancid::groups must be an array. Detected type is ${groups_type}.")
+  if ! is_array($groups) {
+    fail("rancid::groups must be an array.")
   }
 
-  if (! is_array($packages_type)) or (! is_string($packages_type)) {
-    fail("rancid::packages must be an array or a string. Detected type is ${packages_type}.")
+  if (! is_array($packages)) or (! is_string($packages)) {
+    fail("rancid::packages must be an array or a string.")
   }
 
   validate_absolute_path($rancid_config_real)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,7 +119,7 @@ class rancid (
     fail("rancid::groups must be an array.")
   }
 
-  if ! is_array($packages) {
+  if ! is_array($packages_real) {
     fail("rancid::packages must be an array")
   }
 


### PR DESCRIPTION
This PR updates the `rancid` module to no longer use the `type` reserved function, but rather rely on `stdlib` to do the same comparisions. 